### PR TITLE
Build system refactoring: split out QtWebServer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ else()
     find_package(Qt5 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS AndroidExtras)
 endif()
 
-set(qmlevemon_srcs
+set(QMLEVEMON_SRCS
     "src/main.cpp"
     "src/settings.cpp"
     "src/qmlevemon_app.cpp"
@@ -103,41 +103,18 @@ set(qmlevemon_srcs
 )
 
 if (WIN32)
-    list(APPEND qmlevemon_srcs
+    list(APPEND QMLEVEMON_SRCS
         "win32/windows_resources.rc")
 endif()
 
-set(qtwebserver_srcs
-    "src/qtwebserver/tcp/tcpmultithreadedserver.cpp"
-    "src/qtwebserver/tcp/tcpserverthread.cpp"
-    "src/qtwebserver/http/httprequest.cpp"
-    "src/qtwebserver/http/httpstatuscodes.cpp"
-    "src/qtwebserver/http/httpwebengine.cpp"
-    "src/qtwebserver/http/httpresource.cpp"
-    "src/qtwebserver/http/httpiodeviceresource.cpp"
-    "src/qtwebserver/misc/log.cpp"
-    "src/qtwebserver/misc/logger.cpp"
-    "src/qtwebserver/sql/sqlconnectionpool.cpp"
-    "src/qtwebserver/html/htmldocument.cpp"
-    "src/qtwebserver/util/utilassetsresource.cpp"
-    "src/qtwebserver/http/httpresponse.cpp"
-    "src/qtwebserver/http/httpheaders.cpp"
-    "src/qtwebserver/util/utildataurlcodec.cpp"
-    "src/qtwebserver/util/utilformurlcodec.cpp"
-    "src/qtwebserver/css/cssdocument.cpp"
-    "src/qtwebserver/css/cssruleset.cpp"
-    "src/qtwebserver/weblayout.cpp")
+
+add_subdirectory("src/qtwebserver")
+
 
 if (BUILD_FOR_ANDROID)
-    add_library(${PROJECT_NAME} SHARED
-        ${qmlevemon_srcs}
-        ${qtwebserver_srcs}
-    )
+    add_library(${PROJECT_NAME} SHARED ${QMLEVEMON_SRCS})
 else()
-    add_executable(${PROJECT_NAME} WIN32
-        ${qmlevemon_srcs}
-        ${qtwebserver_srcs}
-    )
+    add_executable(${PROJECT_NAME} WIN32 ${QMLEVEMON_SRCS})
 endif()
 
 target_include_directories(${PROJECT_NAME} PRIVATE
@@ -180,6 +157,7 @@ target_link_libraries(${PROJECT_NAME}
     Qt5::Qml
     Qt5::Quick
     Qt5::QuickControls2
+    QtWebServer
 )
 
 # Link Qt5Widgets only for desktop

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,9 @@ pipeline {
                     rem echo INCLUDE: %INCLUDE%
                     rem echo QT_PREFIX: %QT_PREFIX%
                     where cl
+                    where jom
+                    where cmake
+                    where git
                     if exist build rmdir /s /q build
                     mkdir build
                     cd build

--- a/src/qtwebserver/CMakeLists.txt
+++ b/src/qtwebserver/CMakeLists.txt
@@ -1,23 +1,6 @@
-cmake_minimum_required(VERSION 3.7)
+find_package(Qt5 CONFIG REQUIRED COMPONENTS Core Network Xml Sql Gui)
 
-set(QTWEBSERVER_VERSION 0.1.0)
-
-project(QtWebServer LANGUAGES CXX VERSION ${QMLEVEMON_VERSION})
-
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTORCC ON)
-
-find_package(Qt5 COMPONENTS
-    Core
-    Network
-    Xml
-    Sql
-    Gui
-    REQUIRED
-)
-
-add_library(${PROJECT_NAME}
+set(QTWEBSERVER_SRCS
     "tcp/tcpmultithreadedserver.cpp"
     "tcp/tcpserverthread.cpp"
     "http/httprequest.cpp"
@@ -38,7 +21,20 @@ add_library(${PROJECT_NAME}
     "css/cssruleset.cpp"
     "weblayout.cpp")
 
-target_link_libraries(${PROJECT_NAME}
+add_library(QtWebServer STATIC ${QTWEBSERVER_SRCS})
+
+target_compile_definitions(QtWebServer PRIVATE
+    QT_DEPRECATED_WARNINGS
+    QT_NO_CAST_FROM_ASCII
+    QT_NO_CAST_TO_ASCII
+    QT_NO_URL_CAST_FROM_STRING
+    QT_NO_CAST_FROM_BYTEARRAY
+    QT_STRICT_ITERATORS
+    QT_NO_SIGNALS_SLOTS_KEYWORDS
+    QT_USE_QSTRINGBUILDER
+)
+
+target_link_libraries(QtWebServer PUBLIC
     Qt5::Core
     Qt5::Network
     Qt5::Xml

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,27 +1,6 @@
-find_package(Qt5 5.9 CONFIG REQUIRED COMPONENTS
+find_package(Qt5 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS
     Test
 )
-
-set(test_qtwebserver_srcs
-    "../qtwebserver/tcp/tcpmultithreadedserver.cpp"
-    "../qtwebserver/tcp/tcpserverthread.cpp"
-    "../qtwebserver/http/httprequest.cpp"
-    "../qtwebserver/http/httpstatuscodes.cpp"
-    "../qtwebserver/http/httpwebengine.cpp"
-    "../qtwebserver/http/httpresource.cpp"
-    "../qtwebserver/http/httpiodeviceresource.cpp"
-    "../qtwebserver/misc/log.cpp"
-    "../qtwebserver/misc/logger.cpp"
-    "../qtwebserver/sql/sqlconnectionpool.cpp"
-    "../qtwebserver/html/htmldocument.cpp"
-    "../qtwebserver/util/utilassetsresource.cpp"
-    "../qtwebserver/http/httpresponse.cpp"
-    "../qtwebserver/http/httpheaders.cpp"
-    "../qtwebserver/util/utildataurlcodec.cpp"
-    "../qtwebserver/util/utilformurlcodec.cpp"
-    "../qtwebserver/css/cssdocument.cpp"
-    "../qtwebserver/css/cssruleset.cpp"
-    "../qtwebserver/weblayout.cpp")
 
 add_executable(test_qtwebserver "test_qtwebserver.cpp" ${test_qtwebserver_srcs})
 target_include_directories(test_qtwebserver PRIVATE "../qtwebserver")
@@ -32,6 +11,7 @@ target_link_libraries(test_qtwebserver
     Qt5::Sql
     Qt5::Xml
     Qt5::Test
+    QtWebServer
 )
 add_test(NAME test_qtwebserver COMMAND test_qtwebserver)
 


### PR DESCRIPTION
Build QtWebServer separately as a static library inside project tree.
This makes writing tests using QtWebserver a bit easier (link to library instead of including all sources).
Main top level CMakeLists.txt looks cleaner now.